### PR TITLE
Added Career Vault

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Many sites aggregate job listing from a variety of sources, it can 'sometimes' b
 -------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------|--|--|--|--|
 | ❇️ | [RemoteOK](https://remoteok.io/) | Jobs board aggregator. | [JSON](https://remoteok.io/remote-jobs.json)| 50,000 |🌟|
 | ❇️ | [Who Is Hiring](https://whoishiring.io) | Jobs board aggregator. | | 300,000 |🌟|
+| ❇️ | [Career Vault](https://careervault.io) | Jobs board aggregator. | | 400,000 |🌟|
 | ❇️ | [Remotely Awesome Jobs](https://www.remotelyawesomejobs.com/) | Jobs board aggregator. | | 400,000 |🌟|
 | ❇️ | [Crypto Jobs List](https://cryptojobslist.com/remote/blockchain-jobs) | Jobs board aggregator. | [RSS](https://cryptojobslist.com/jobs.rss) | 400,000 | 🌟|
 | ❇️ | [Ditch The Office](https://ditchtheoffice.co) | Jobs board aggregator. | | 700,000 | 🌟|


### PR DESCRIPTION
Check it out here: https://www.careervault.io

Career Vault finds over 20x more remote jobs than other popular job boards, such as RemoteOK and WeWorkRemotely, and links applicants directly to the original job posting. It's free for job seekers, doesn't require signing up, and doesn't have any obsolete postings (those are automatically deleted). The current Alexa ranking is 411,342.